### PR TITLE
Use team logos for league displays

### DIFF
--- a/components/MatchupDetail.tsx
+++ b/components/MatchupDetail.tsx
@@ -48,6 +48,8 @@ export default function MatchupDetail({ matchups, rosters, users, matchupId, wee
   const team2 = matchupTeams[1]
   const user1 = getUserByRosterId(team1.roster_id)
   const user2 = team2 ? getUserByRosterId(team2.roster_id) : null
+  const avatar1 = user1?.metadata?.avatar || user1?.avatar
+  const avatar2 = user2?.metadata?.avatar || user2?.avatar
 
   // Determine if the matchup is completed
   // A matchup is considered complete if it's from a past week, or if it has a clear winner with different points
@@ -149,10 +151,10 @@ export default function MatchupDetail({ matchups, rosters, users, matchupId, wee
         <div className="bg-gray-800 rounded-lg p-6">
           <div className="text-center mb-6">
             <div className="flex items-center justify-center mb-2">
-              {user1?.avatar && (
+              {avatar1 && (
                 <Image
-                  src={`https://sleepercdn.com/avatars/${user1.avatar}`}
-                  alt={user1.display_name || user1.username || 'User'}
+                  src={`https://sleepercdn.com/avatars/${avatar1}`}
+                  alt={user1?.display_name || user1?.username || 'User'}
                   width={48}
                   height={48}
                   className="w-12 h-12 rounded-full mr-3"
@@ -160,9 +162,9 @@ export default function MatchupDetail({ matchups, rosters, users, matchupId, wee
               )}
               <div className="text-center">
                 <h3 className="text-xl font-semibold">
-                  {(user1 as any)?.metadata?.team_name || user1?.display_name || user1?.username || 'Unknown'}
+                  {user1?.metadata?.team_name || user1?.display_name || user1?.username || 'Unknown'}
                 </h3>
-                {(user1 as any)?.metadata?.team_name && (
+                {user1?.metadata?.team_name && (
                   <div className="text-sm text-gray-400">
                     {user1?.display_name || user1?.username}
                   </div>
@@ -196,10 +198,10 @@ export default function MatchupDetail({ matchups, rosters, users, matchupId, wee
         <div className={`bg-gray-800 rounded-lg p-6 ${winner?.roster_id === team1.roster_id ? 'ring-2 ring-green-400' : ''}`}>
           <div className="text-center mb-6">
             <div className="flex items-center justify-center mb-2">
-              {user1?.avatar && (
+              {avatar1 && (
                 <Image
-                  src={`https://sleepercdn.com/avatars/${user1.avatar}`}
-                  alt={user1.display_name || user1.username || 'User'}
+                  src={`https://sleepercdn.com/avatars/${avatar1}`}
+                  alt={user1?.display_name || user1?.username || 'User'}
                   width={48}
                   height={48}
                   className="w-12 h-12 rounded-full mr-3"
@@ -207,9 +209,9 @@ export default function MatchupDetail({ matchups, rosters, users, matchupId, wee
               )}
               <div className="text-center">
                 <h3 className="text-xl font-semibold">
-                  {(user1 as any)?.metadata?.team_name || user1?.display_name || user1?.username || 'Unknown'}
+                  {user1?.metadata?.team_name || user1?.display_name || user1?.username || 'Unknown'}
                 </h3>
-                {(user1 as any)?.metadata?.team_name && (
+                {user1?.metadata?.team_name && (
                   <div className="text-sm text-gray-400">
                     {user1?.display_name || user1?.username}
                   </div>
@@ -230,10 +232,10 @@ export default function MatchupDetail({ matchups, rosters, users, matchupId, wee
         <div className={`bg-gray-800 rounded-lg p-6 ${winner?.roster_id === team2.roster_id ? 'ring-2 ring-green-400' : ''}`}>
           <div className="text-center mb-6">
             <div className="flex items-center justify-center mb-2">
-              {user2?.avatar && (
+              {avatar2 && (
                 <Image
-                  src={`https://sleepercdn.com/avatars/${user2.avatar}`}
-                  alt={user2.display_name || user2.username || 'User'}
+                  src={`https://sleepercdn.com/avatars/${avatar2}`}
+                  alt={user2?.display_name || user2?.username || 'User'}
                   width={48}
                   height={48}
                   className="w-12 h-12 rounded-full mr-3"
@@ -241,9 +243,9 @@ export default function MatchupDetail({ matchups, rosters, users, matchupId, wee
               )}
               <div className="text-center">
                 <h3 className="text-xl font-semibold">
-                  {(user2 as any)?.metadata?.team_name || user2?.display_name || user2?.username || 'Unknown'}
+                  {user2?.metadata?.team_name || user2?.display_name || user2?.username || 'Unknown'}
                 </h3>
-                {(user2 as any)?.metadata?.team_name && (
+                {user2?.metadata?.team_name && (
                   <div className="text-sm text-gray-400">
                     {user2?.display_name || user2?.username}
                   </div>

--- a/components/Matchups.tsx
+++ b/components/Matchups.tsx
@@ -63,14 +63,15 @@ export default function Matchups({ matchups, rosters, users, week, league, playe
           
           if (!team2) {
             const user1 = getUserByRosterId(team1.roster_id)
+            const avatar1 = user1?.metadata?.avatar || user1?.avatar
             return (
               <div key={index} className="bg-gray-800 rounded-lg p-4">
                 <div className="text-center">
                   <div className="flex items-center justify-center mb-2">
-                    {user1?.avatar && (
+                    {avatar1 && (
                       <Image
-                        src={`https://sleepercdn.com/avatars/${user1.avatar}`}
-                        alt={user1.display_name || user1.username || 'User'}
+                        src={`https://sleepercdn.com/avatars/${avatar1}`}
+                        alt={user1?.display_name || user1?.username || 'User'}
                         width={32}
                         height={32}
                         className="w-8 h-8 rounded-full mr-3"
@@ -78,9 +79,9 @@ export default function Matchups({ matchups, rosters, users, week, league, playe
                     )}
                     <div>
                       <div className="font-medium">
-                        {(user1 as any)?.metadata?.team_name || user1?.display_name || user1?.username || 'Unknown'}
+                        {user1?.metadata?.team_name || user1?.display_name || user1?.username || 'Unknown'}
                       </div>
-                      {(user1 as any)?.metadata?.team_name && (
+                      {user1?.metadata?.team_name && (
                         <div className="text-xs text-gray-400">
                           {user1?.display_name || user1?.username}
                         </div>
@@ -96,6 +97,8 @@ export default function Matchups({ matchups, rosters, users, week, league, playe
 
           const user1 = getUserByRosterId(team1.roster_id)
           const user2 = getUserByRosterId(team2.roster_id)
+          const avatar1 = user1?.metadata?.avatar || user1?.avatar
+          const avatar2 = user2?.metadata?.avatar || user2?.avatar
           const winner = team1.points > team2.points ? team1 : team2.points > team1.points ? team2 : null
 
           return (
@@ -107,10 +110,10 @@ export default function Matchups({ matchups, rosters, users, week, league, playe
               <div className="flex justify-between items-center">
                 <div className="flex-1">
                   <div className={`flex items-center mb-2 ${winner?.roster_id === team1.roster_id && areMatchupsComplete ? 'text-green-400' : ''}`}>
-                    {user1?.avatar && (
+                    {avatar1 && (
                       <Image
-                        src={`https://sleepercdn.com/avatars/${user1.avatar}`}
-                        alt={user1.display_name || user1.username || 'User'}
+                        src={`https://sleepercdn.com/avatars/${avatar1}`}
+                        alt={user1?.display_name || user1?.username || 'User'}
                         width={32}
                         height={32}
                         className="w-8 h-8 rounded-full mr-3"
@@ -118,9 +121,9 @@ export default function Matchups({ matchups, rosters, users, week, league, playe
                     )}
                     <div>
                       <div className="font-medium">
-                        {(user1 as any)?.metadata?.team_name || user1?.display_name || user1?.username || 'Unknown'}
+                        {user1?.metadata?.team_name || user1?.display_name || user1?.username || 'Unknown'}
                       </div>
-                      {(user1 as any)?.metadata?.team_name && (
+                      {user1?.metadata?.team_name && (
                         <div className="text-xs text-gray-400">
                           {user1?.display_name || user1?.username}
                         </div>
@@ -128,10 +131,10 @@ export default function Matchups({ matchups, rosters, users, week, league, playe
                     </div>
                   </div>
                   <div className={`flex items-center ${winner?.roster_id === team2.roster_id && areMatchupsComplete ? 'text-green-400' : ''}`}>
-                    {user2?.avatar && (
+                    {avatar2 && (
                       <Image
-                        src={`https://sleepercdn.com/avatars/${user2.avatar}`}
-                        alt={user2.display_name || user2.username || 'User'}
+                        src={`https://sleepercdn.com/avatars/${avatar2}`}
+                        alt={user2?.display_name || user2?.username || 'User'}
                         width={32}
                         height={32}
                         className="w-8 h-8 rounded-full mr-3"
@@ -139,9 +142,9 @@ export default function Matchups({ matchups, rosters, users, week, league, playe
                     )}
                     <div>
                       <div className="font-medium">
-                        {(user2 as any)?.metadata?.team_name || user2?.display_name || user2?.username || 'Unknown'}
+                        {user2?.metadata?.team_name || user2?.display_name || user2?.username || 'Unknown'}
                       </div>
-                      {(user2 as any)?.metadata?.team_name && (
+                      {user2?.metadata?.team_name && (
                         <div className="text-xs text-gray-400">
                           {user2?.display_name || user2?.username}
                         </div>

--- a/components/RosterView.tsx
+++ b/components/RosterView.tsx
@@ -88,15 +88,16 @@ export default function RosterView({ roster, user, players, onClose }: RosterVie
   }
 
   const { startersByPosition, bench } = getPlayersByPosition()
+  const avatar = user?.metadata?.avatar || user?.avatar
 
   return (
     <div className="bg-gray-800 rounded-lg p-6 h-full overflow-y-auto">
       {/* Header */}
       <div className="flex justify-between items-center mb-6">
         <div className="flex items-center">
-          {user?.avatar && (
+          {avatar && (
             <Image
-              src={`https://sleepercdn.com/avatars/${user.avatar}`}
+              src={`https://sleepercdn.com/avatars/${avatar}`}
               alt={user.display_name || user.username || 'User'}
               width={40}
               height={40}
@@ -105,9 +106,9 @@ export default function RosterView({ roster, user, players, onClose }: RosterVie
           )}
           <div>
             <h3 className="text-lg font-semibold">
-              {(user as any)?.metadata?.team_name || user?.display_name || user?.username || 'Unknown'}
+              {user?.metadata?.team_name || user?.display_name || user?.username || 'Unknown'}
             </h3>
-            {(user as any)?.metadata?.team_name && (
+            {user?.metadata?.team_name && (
               <div className="text-sm text-gray-400">
                 {user?.display_name || user?.username}
               </div>

--- a/components/Standings.tsx
+++ b/components/Standings.tsx
@@ -61,14 +61,15 @@ export default function Standings({ rosters, users, players }: StandingsProps) {
             <tbody className="divide-y divide-gray-700">
               {sortedRosters.map((roster, index) => {
                 const user = getUserByOwnerId(roster.owner_id)
+                const avatar = user?.metadata?.avatar || user?.avatar
                 const totalGames = roster.settings.wins + roster.settings.losses + roster.settings.ties
                 const winPct = totalGames > 0 ? (roster.settings.wins / totalGames * 100).toFixed(1) : '0.0'
                 const pointsFor = ((roster.settings.fpts || 0) + ((roster.settings.fpts_decimal || 0) / 100)).toFixed(2)
                 const pointsAgainst = ((roster.settings.fpts_against || 0) + ((roster.settings.fpts_against_decimal || 0) / 100)).toFixed(2)
-                
+
                 return (
-                  <tr 
-                    key={roster.roster_id} 
+                  <tr
+                    key={roster.roster_id}
                     onClick={() => handleRowClick(roster)}
                     className={`hover:bg-gray-750 cursor-pointer transition-colors ${
                       selectedRoster?.roster_id === roster.roster_id ? 'bg-blue-900' : ''
@@ -77,10 +78,10 @@ export default function Standings({ rosters, users, players }: StandingsProps) {
                     <td className="px-4 py-3 text-sm font-medium">{index + 1}</td>
                     <td className="px-4 py-3">
                       <div className="flex items-center">
-                        {user?.avatar && (
+                        {avatar && (
                           <Image
-                            src={`https://sleepercdn.com/avatars/${user.avatar}`}
-                            alt={user.display_name || user.username || 'User'}
+                            src={`https://sleepercdn.com/avatars/${avatar}`}
+                            alt={user?.display_name || user?.username || 'User'}
                             width={32}
                             height={32}
                             className="w-8 h-8 rounded-full mr-3"
@@ -88,9 +89,9 @@ export default function Standings({ rosters, users, players }: StandingsProps) {
                         )}
                         <div>
                           <div className="text-sm font-medium">
-                            {(user as any)?.metadata?.team_name || user?.display_name || user?.username || 'Unknown'}
+                            {user?.metadata?.team_name || user?.display_name || user?.username || 'Unknown'}
                           </div>
-                          {(user as any)?.metadata?.team_name && (
+                          {user?.metadata?.team_name && (
                             <div className="text-xs text-gray-400">
                               {user?.display_name || user?.username}
                             </div>

--- a/types/sleeper.ts
+++ b/types/sleeper.ts
@@ -3,6 +3,11 @@ export interface SleeperUser {
   username: string
   display_name: string
   avatar: string
+  metadata?: {
+    team_name?: string
+    avatar?: string
+    [key: string]: any
+  }
 }
 
 export interface SleeperLeague {


### PR DESCRIPTION
## Summary
- Show team logo instead of user avatar across standings, matchups, and rosters
- Support team metadata on `SleeperUser`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be3877ef5c832fa3fe1d52d9ead6e6