### PR TITLE
Highlight live players in matchup view

### DIFF
--- a/app/api/live-teams/route.ts
+++ b/app/api/live-teams/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  try {
+    const res = await fetch('https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard', { next: { revalidate: 30 } })
+    if (!res.ok) {
+      return NextResponse.json({ teams: [] }, { status: res.status })
+    }
+    const data = await res.json()
+    const teams: string[] = []
+    for (const event of data.events || []) {
+      const competition = event.competitions?.[0]
+      if (competition?.status?.type?.state === 'in') {
+        for (const comp of competition.competitors || []) {
+          const abbr = comp.team?.abbreviation
+          if (abbr && !teams.includes(abbr)) {
+            teams.push(abbr)
+          }
+        }
+      }
+    }
+    return NextResponse.json({ teams })
+  } catch (error) {
+    console.error('Error fetching live teams:', error)
+    return NextResponse.json({ teams: [] }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add live-teams API that reads ESPN's NFL scoreboard
- show "LIVE" indicator on players whose teams are currently playing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be3a0ab204832fa317e9c852fe62d0