### PR TITLE
Improve bye week detection for matchup detail badges

### DIFF
--- a/components/MatchupDetail.tsx
+++ b/components/MatchupDetail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { SleeperMatchup, SleeperRoster, SleeperUser, SleeperLeague } from '@/types/sleeper'
 import { createBestBallMatchup, isBestBallLeague } from '@/lib/best-ball'
 
@@ -19,6 +19,17 @@ interface MatchupDetailProps {
 
 export default function MatchupDetail({ matchups, rosters, users, matchupId, week, players, league, currentWeek, onBack }: MatchupDetailProps) {
   const [liveTeams, setLiveTeams] = useState<Set<string>>(new Set())
+
+  const rosterPlayerSets = useMemo(() => {
+    const map = new Map<number, Set<string>>()
+
+    rosters.forEach(roster => {
+      const playerIds = (roster.players || []).filter((id): id is string => Boolean(id))
+      map.set(roster.roster_id, new Set(playerIds))
+    })
+
+    return map
+  }, [rosters])
 
   useEffect(() => {
     const loadLiveTeams = async () => {
@@ -75,13 +86,37 @@ export default function MatchupDetail({ matchups, rosters, users, matchupId, wee
   // A matchup is considered complete if it's from a past week, or if it has a clear winner with different points
   const isMatchupComplete = currentWeek ? week < currentWeek : (team1.points !== team2?.points && (team1.points > 0 || team2?.points > 0))
 
+  const parseByeWeeks = (byeData: unknown): number[] => {
+    if (!byeData) {
+      return []
+    }
+
+    if (Array.isArray(byeData)) {
+      return byeData.flatMap(value => parseByeWeeks(value))
+    }
+
+    if (typeof byeData === 'number') {
+      return Number.isFinite(byeData) ? [byeData] : []
+    }
+
+    if (typeof byeData === 'string') {
+      const parsed = parseInt(byeData, 10)
+      return Number.isNaN(parsed) ? [] : [parsed]
+    }
+
+    if (typeof byeData === 'object') {
+      return Object.values(byeData as Record<string, unknown>).flatMap(value => parseByeWeeks(value))
+    }
+
+    return []
+  }
+
   const renderPlayerPoints = (matchup: SleeperMatchup) => {
     const starterIds = new Set(matchup.starters)
     const isBestBall = isBestBallLeague(league)
     
-    const renderPlayer = (playerId: string, points: number, isStarter: boolean = false) => {
-      const player = players[playerId]
-      if (!player && !playerId) {
+    const renderPlayer = (playerId: string, points: number, isStarter: boolean = false, rosterPlayers?: Set<string>) => {
+      if (!playerId) {
         return (
           <div className="flex justify-between items-center py-2 px-3 bg-gray-700 rounded">
             <span className="text-sm text-gray-400">Empty Slot</span>
@@ -89,38 +124,109 @@ export default function MatchupDetail({ matchups, rosters, users, matchupId, wee
           </div>
         )
       }
-      
+
+      const player = players[playerId]
+      const isOnRoster = rosterPlayers?.has(playerId) ?? false
+
+      const byeWeeks = [
+        ...parseByeWeeks(player?.bye_weeks),
+        ...parseByeWeeks(player?.bye_week)
+      ]
+      const uniqueByeWeeks = Array.from(new Set(byeWeeks))
+      const isOnBye = uniqueByeWeeks.includes(week)
+
+      const metadataItems: ReactNode[] = []
+
+      if (player) {
+        metadataItems.push(
+          <span key="position" className="text-gray-400">
+            {player.position} • {player.team || 'FA'}
+          </span>
+        )
+
+        if (player.team && liveTeams.has(player.team)) {
+          metadataItems.push(
+            <span key="live" className="inline-flex items-center text-green-400">
+              <span className="w-2 h-2 bg-green-400 rounded-full animate-pulse mr-1" />
+              LIVE
+            </span>
+          )
+        }
+
+        if (player.injury_status && player.injury_status !== 'Healthy') {
+          metadataItems.push(
+            <span key="injury" className="text-red-400">
+              ({player.injury_status})
+            </span>
+          )
+        }
+      }
+
+      if (!isOnRoster) {
+        metadataItems.push(
+          <span
+            key="dropped"
+            className="inline-flex items-center rounded bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-300"
+          >
+            Not on Roster
+          </span>
+        )
+      }
+
+      if (isOnBye) {
+        metadataItems.push(
+          <span
+            key="bye"
+            className="inline-flex items-center rounded bg-purple-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-purple-300"
+          >
+            Bye Week
+          </span>
+        )
+      }
+
       if (!player) {
         return (
-          <div className="flex justify-between items-center py-2 px-3 bg-gray-700 rounded">
-            <span className="text-sm">{playerId}</span>
-            <span className="font-medium">{points?.toFixed(2) || '0.00'}</span>
+          <div className={`flex items-center justify-between py-2 px-3 rounded ${isStarter ? 'bg-gray-700' : 'bg-gray-800'}`}>
+            <div className="flex items-center flex-1">
+              <div className="w-10 h-10 bg-gray-600 rounded-full flex items-center justify-center mr-3 text-xs font-bold">
+                {playerId.replace(/[^A-Za-z0-9]/g, '').slice(0, 2).toUpperCase() || '??'}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium truncate">{playerId}</div>
+                {metadataItems.length > 0 && (
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                    {metadataItems}
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="text-right">
+              <div className="font-medium">{points?.toFixed(2) || '0.00'}</div>
+            </div>
           </div>
         )
       }
-      
+
+      const name = player.full_name || [player.first_name, player.last_name].filter(Boolean).join(' ') || playerId
+      const firstInitial = player.first_name?.[0] ?? ''
+      const lastInitial = player.last_name?.[0] ?? ''
+      const initials = (firstInitial + lastInitial) || player.position || '??'
+
       return (
         <div className={`flex items-center justify-between py-2 px-3 rounded ${isStarter ? 'bg-gray-700' : 'bg-gray-800'}`}>
           <div className="flex items-center flex-1">
             <div className="w-10 h-10 bg-gray-600 rounded-full flex items-center justify-center mr-3 text-xs font-bold">
-              {player.first_name?.[0]}{player.last_name?.[0]}
+              {initials}
             </div>
             <div className="flex-1 min-w-0">
               <div className="text-sm font-medium truncate">
-                {player.full_name || `${player.first_name} ${player.last_name}`}
+                {name}
               </div>
-              <div className="text-xs text-gray-400">
-                {player.position} • {player.team || 'FA'}
-                {player.team && liveTeams.has(player.team) && (
-                  <span className="ml-2 inline-flex items-center text-green-400">
-                    <span className="w-2 h-2 bg-green-400 rounded-full animate-pulse mr-1" />
-                    LIVE
-                  </span>
-                )}
-                {player.injury_status && player.injury_status !== 'Healthy' && (
-                  <span className="text-red-400 ml-1">({player.injury_status})</span>
-                )}
-              </div>
+              {metadataItems.length > 0 && (
+                <div className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                  {metadataItems}
+                </div>
+              )}
             </div>
           </div>
           <div className="text-right">
@@ -138,9 +244,9 @@ export default function MatchupDetail({ matchups, rosters, users, matchupId, wee
             {isBestBall && <span className="text-xs bg-blue-600 px-2 py-1 rounded">AUTO</span>}
           </h4>
           <div className="space-y-2">
-            {matchup.starters.map((playerId, index) => 
+            {matchup.starters.map((playerId, index) =>
               <div key={`starter-${playerId}-${index}`}>
-                {renderPlayer(playerId, matchup.starters_points[index], true)}
+                {renderPlayer(playerId, matchup.starters_points[index], true, rosterPlayerSets.get(matchup.roster_id))}
               </div>
             )}
           </div>
@@ -151,9 +257,9 @@ export default function MatchupDetail({ matchups, rosters, users, matchupId, wee
           <div className="space-y-2">
             {matchup.players
               .filter(playerId => !starterIds.has(playerId))
-              .map((playerId) => 
+              .map((playerId) =>
                 <div key={`bench-${playerId}`}>
-                  {renderPlayer(playerId, matchup.players_points[playerId], false)}
+                  {renderPlayer(playerId, matchup.players_points[playerId], false, rosterPlayerSets.get(matchup.roster_id))}
                 </div>
               )}
           </div>


### PR DESCRIPTION
## Summary
- indicate when matchup players are no longer on their current roster
- display bye week badges alongside player metadata in the matchup detail view with resilient parsing for Sleeper bye data
- build a reusable roster lookup to preserve existing live and injury indicators

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3f13c78ec832fa64f8fe25399a58d